### PR TITLE
Fix cross-provider resume conversion and budget large-session context

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,23 @@ enum Command {
         /// Add context messages to help the target agent understand the conversion.
         #[arg(long)]
         enrich: bool,
+
+        /// Cap the transferred history at roughly this many tokens (0 = unlimited).
+        /// Applies to cross-provider conversions; the oldest turns are dropped
+        /// first, pinning the original task and the most recent history.
+        #[arg(long, default_value = "200000")]
+        max_context_tokens: usize,
+
+        /// Truncate each tool result/observation to this many characters
+        /// (0 = unlimited). Tool output is usually the bulk of a long session.
+        #[arg(long, default_value = "4000")]
+        max_tool_output: usize,
+
+        /// Keep the source agent's reasoning traces (dropped by default for
+        /// cross-agent handoffs, since the target can't use another agent's
+        /// hidden reasoning).
+        #[arg(long)]
+        keep_reasoning: bool,
     },
 
     /// List all discoverable sessions across installed providers.
@@ -230,6 +247,9 @@ fn main() -> ExitCode {
             force,
             source,
             enrich,
+            max_context_tokens,
+            max_tool_output,
+            keep_reasoning,
         } => cmd_resume(
             &target,
             &session_id,
@@ -237,6 +257,9 @@ fn main() -> ExitCode {
             force,
             source,
             enrich,
+            max_context_tokens,
+            max_tool_output,
+            keep_reasoning,
             cli.json,
         ),
         Command::List {
@@ -301,6 +324,7 @@ fn error_type_name(e: &anyhow::Error) -> &'static str {
 // Command implementations
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_resume(
     target: &str,
     session_id: &str,
@@ -308,6 +332,9 @@ fn cmd_resume(
     force: bool,
     source: Option<String>,
     enrich: bool,
+    max_context_tokens: usize,
+    max_tool_output: usize,
+    keep_reasoning: bool,
     json_mode: bool,
 ) -> anyhow::Result<()> {
     let registry = ProviderRegistry::default_registry();
@@ -319,6 +346,9 @@ fn cmd_resume(
         verbose: false,
         enrich,
         source_hint: source,
+        max_context_tokens,
+        max_tool_output,
+        keep_reasoning,
     };
 
     let result = pipeline.convert(target, session_id, opts)?;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -409,36 +409,46 @@ but resume may fail until the CLI is installed.",
         //
         // Fix: materialise the tool-call/result text into `content` on the
         // canonical message itself so that write ↔ readback is consistent.
-        for msg in &mut canonical.messages {
-            if !msg.content.trim().is_empty() {
-                continue;
-            }
-
-            let has_tool_calls = !msg.tool_calls.is_empty();
-            let has_tool_results = !msg.tool_results.is_empty();
-
-            if !has_tool_calls && !has_tool_results {
-                continue;
-            }
-
-            let mut parts: Vec<String> = Vec::new();
-
-            // Synthesize text for tool calls (matches Pi reader's format).
-            for tc in &msg.tool_calls {
-                parts.push(format!("[Tool: {}]", tc.name));
-            }
-
-            // Synthesize text for tool results.
-            for tr in &msg.tool_results {
-                if tr.is_error {
-                    parts.push(format!("[Tool Error] {}", tr.content));
-                } else {
-                    parts.push(format!("[Tool Output] {}", tr.content));
+        //
+        // Skipped for structured-tool targets (Claude Code), which round-trip
+        // `tool_use` / `tool_result` as native content blocks and read them
+        // back into `tool_calls` / `tool_results` (not `content`). Synthesizing
+        // text there would corrupt the round-trip and, worse, force tool output
+        // to be replayed as a text block the Anthropic API rejects alongside
+        // the matching `tool_result`.
+        let target_preserves_tool_blocks = target_provider.slug() == "claude-code";
+        if !target_preserves_tool_blocks {
+            for msg in &mut canonical.messages {
+                if !msg.content.trim().is_empty() {
+                    continue;
                 }
-            }
 
-            if !parts.is_empty() {
-                msg.content = parts.join("\n");
+                let has_tool_calls = !msg.tool_calls.is_empty();
+                let has_tool_results = !msg.tool_results.is_empty();
+
+                if !has_tool_calls && !has_tool_results {
+                    continue;
+                }
+
+                let mut parts: Vec<String> = Vec::new();
+
+                // Synthesize text for tool calls (matches Pi reader's format).
+                for tc in &msg.tool_calls {
+                    parts.push(format!("[Tool: {}]", tc.name));
+                }
+
+                // Synthesize text for tool results.
+                for tr in &msg.tool_results {
+                    if tr.is_error {
+                        parts.push(format!("[Tool Error] {}", tr.content));
+                    } else {
+                        parts.push(format!("[Tool Output] {}", tr.content));
+                    }
+                }
+
+                if !parts.is_empty() {
+                    msg.content = parts.join("\n");
+                }
             }
         }
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -29,6 +29,31 @@ pub struct ConvertOptions {
     pub verbose: bool,
     pub enrich: bool,
     pub source_hint: Option<String>,
+    /// Cap the transferred history at roughly this many tokens (0 = unlimited).
+    /// Applied only to cross-provider conversions; mirrors the source agent's
+    /// live context rather than its full archive.
+    pub max_context_tokens: usize,
+    /// Truncate each tool result/observation to this many characters (0 = unlimited).
+    pub max_tool_output: usize,
+    /// Keep source-agent reasoning traces (dropped by default for cross-agent
+    /// handoffs since the target agent cannot use another agent's hidden reasoning).
+    pub keep_reasoning: bool,
+}
+
+impl Default for ConvertOptions {
+    fn default() -> Self {
+        // No-op budgeting by default; the CLI layer supplies the smart caps.
+        ConvertOptions {
+            dry_run: false,
+            force: false,
+            verbose: false,
+            enrich: false,
+            source_hint: None,
+            max_context_tokens: 0,
+            max_tool_output: 0,
+            keep_reasoning: true,
+        }
+    }
 }
 
 /// Outcome of a successful (or dry-run) conversion.
@@ -397,6 +422,22 @@ but resume may fail until the CLI is installed.",
             });
         }
 
+        // 7a2. Context budget (cross-provider only — same-provider short-circuited above).
+        //
+        // The source reader already collapses the on-disk archive to the live
+        // context (honoring compaction). This step keeps that context inside a
+        // target-friendly budget: drop the source agent's hidden reasoning,
+        // truncate oversized tool observations, then drop the oldest turns if
+        // still over the token cap — preserving the original task message and
+        // the most recent history, and never severing tool_use/tool_result pairs.
+        let budget_warnings = apply_context_budget(
+            &mut canonical,
+            opts.max_context_tokens,
+            opts.max_tool_output,
+            opts.keep_reasoning,
+        );
+        all_warnings.extend(budget_warnings);
+
         // 7b. Normalize tool-only messages with empty content.
         //
         // Some source formats (notably Codex with `originator: codex_exec`)
@@ -514,6 +555,150 @@ but resume may fail until the CLI is installed.",
             warnings: all_warnings,
         })
     }
+}
+
+/// Rough token estimate (~4 chars/token) for one message including tool I/O.
+fn estimate_message_tokens(m: &CanonicalMessage) -> usize {
+    let mut chars = m.content.len();
+    for tc in &m.tool_calls {
+        chars += tc.name.len() + tc.arguments.to_string().len();
+    }
+    for tr in &m.tool_results {
+        chars += tr.content.len();
+    }
+    chars / 4 + 1
+}
+
+/// Trim a string to ~`max` chars, keeping head and tail with an elision marker.
+/// Returns `None` if no truncation was needed.
+fn elide_middle(s: &str, max: usize) -> Option<String> {
+    if max == 0 {
+        return None;
+    }
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= max {
+        return None;
+    }
+    let head_len = max.saturating_mul(2) / 3;
+    let tail_len = max.saturating_sub(head_len);
+    let omitted = chars.len() - head_len - tail_len;
+    let head: String = chars[..head_len].iter().collect();
+    let tail: String = chars[chars.len() - tail_len..].iter().collect();
+    Some(format!("{head}\n…[casr: {omitted} chars elided]…\n{tail}"))
+}
+
+/// Remove `tool_use` blocks lacking a matching `tool_result` (and vice versa),
+/// then drop any message left with no content and no tool payloads. Keeps the
+/// session valid for APIs that require paired tool calls/results — important
+/// after older turns are dropped by the token budget.
+fn repair_tool_pairing(session: &mut CanonicalSession) {
+    let result_ids: std::collections::HashSet<String> = session
+        .messages
+        .iter()
+        .flat_map(|m| m.tool_results.iter())
+        .filter_map(|tr| tr.call_id.clone())
+        .collect();
+    let call_ids: std::collections::HashSet<String> = session
+        .messages
+        .iter()
+        .flat_map(|m| m.tool_calls.iter())
+        .filter_map(|tc| tc.id.clone())
+        .collect();
+    for m in &mut session.messages {
+        m.tool_calls.retain(|tc| match tc.id.as_deref() {
+            Some(id) => result_ids.contains(id),
+            None => true,
+        });
+        m.tool_results.retain(|tr| match tr.call_id.as_deref() {
+            Some(id) => call_ids.contains(id),
+            None => true,
+        });
+    }
+    session.messages.retain(|m| {
+        !(m.content.trim().is_empty() && m.tool_calls.is_empty() && m.tool_results.is_empty())
+    });
+}
+
+/// Fit a (cross-provider) session into a target-friendly context budget while
+/// preserving its meaning: drop the source agent's hidden reasoning, truncate
+/// oversized tool observations, then drop the oldest turns if still over the
+/// token cap — always pinning the first (task) message and never leaving an
+/// unpaired tool call/result behind. Returns human-readable notes about what
+/// was elided (callers surface these as warnings — never silent).
+fn apply_context_budget(
+    canonical: &mut CanonicalSession,
+    max_tokens: usize,
+    max_tool_output: usize,
+    keep_reasoning: bool,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+
+    // 1. Drop source-agent reasoning traces (unusable by another agent).
+    if !keep_reasoning {
+        let before = canonical.messages.len();
+        canonical
+            .messages
+            .retain(|m| m.author.as_deref() != Some("reasoning"));
+        let dropped = before - canonical.messages.len();
+        if dropped > 0 {
+            warnings.push(format!(
+                "Dropped {dropped} source reasoning trace(s); pass --keep-reasoning to retain."
+            ));
+        }
+    }
+
+    // 2. Truncate oversized tool observations (the dominant byte source).
+    if max_tool_output > 0 {
+        let mut truncated = 0usize;
+        for m in &mut canonical.messages {
+            for tr in &mut m.tool_results {
+                if let Some(short) = elide_middle(&tr.content, max_tool_output) {
+                    tr.content = short;
+                    truncated += 1;
+                }
+            }
+        }
+        if truncated > 0 {
+            warnings.push(format!(
+                "Truncated {truncated} oversized tool result(s) to ~{max_tool_output} chars each."
+            ));
+        }
+    }
+
+    // 3. Enforce the token budget by dropping the oldest turns, pinning the
+    //    first (task) message and keeping the most recent history.
+    if max_tokens > 0 && canonical.messages.len() > 1 {
+        let total: usize = canonical.messages.iter().map(estimate_message_tokens).sum();
+        if total > max_tokens {
+            let pinned = estimate_message_tokens(&canonical.messages[0]);
+            let mut budget_left = max_tokens.saturating_sub(pinned);
+            let mut keep_from = canonical.messages.len();
+            for i in (1..canonical.messages.len()).rev() {
+                let t = estimate_message_tokens(&canonical.messages[i]);
+                if t > budget_left {
+                    break;
+                }
+                budget_left -= t;
+                keep_from = i;
+            }
+            if keep_from > 1 {
+                let dropped = keep_from - 1;
+                let tail = canonical.messages.split_off(keep_from);
+                canonical.messages.truncate(1);
+                canonical.messages.extend(tail);
+                warnings.push(format!(
+                    "Context budget (~{max_tokens} tokens) exceeded; dropped {dropped} older \
+turn(s) between the task and the most recent history."
+                ));
+            }
+        }
+    }
+
+    // 4. Keep tool calls/results paired after any dropping, then re-index.
+    repair_tool_pairing(canonical);
+    reindex_messages(&mut canonical.messages);
+
+    warnings
 }
 
 /// Coarse role bucket used for read-back verification.
@@ -879,6 +1064,7 @@ fn find_backup_path(target: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::{ToolCall, ToolResult};
     use std::{
         fs,
         path::{Path, PathBuf},
@@ -1156,5 +1342,116 @@ mod tests {
             !target.exists(),
             "target should be removed when no backup is available"
         );
+    }
+
+    // -- Context budget ----------------------------------------------------
+
+    fn bmsg(role: MessageRole, content: &str) -> CanonicalMessage {
+        CanonicalMessage {
+            idx: 0,
+            role,
+            content: content.to_string(),
+            timestamp: None,
+            author: None,
+            tool_calls: vec![],
+            tool_results: vec![],
+            extra: serde_json::Value::Null,
+        }
+    }
+
+    fn bsession(messages: Vec<CanonicalMessage>) -> CanonicalSession {
+        CanonicalSession {
+            session_id: "s".into(),
+            provider_slug: "codex".into(),
+            workspace: None,
+            title: None,
+            started_at: None,
+            ended_at: None,
+            messages,
+            metadata: serde_json::Value::Null,
+            source_path: std::path::PathBuf::from("/tmp/x"),
+            model_name: None,
+        }
+    }
+
+    #[test]
+    fn budget_elide_middle_truncates_only_when_needed() {
+        assert!(elide_middle("short", 100).is_none());
+        let long = "x".repeat(1000);
+        let out = elide_middle(&long, 100).expect("should truncate");
+        assert!(out.chars().count() < 250);
+        assert!(out.contains("elided"));
+    }
+
+    #[test]
+    fn budget_drops_reasoning_and_truncates_tool_output() {
+        let mut reasoning = bmsg(MessageRole::Assistant, "secret thoughts");
+        reasoning.author = Some("reasoning".into());
+        let mut call = bmsg(MessageRole::Assistant, "run it");
+        call.tool_calls.push(ToolCall {
+            id: Some("c1".into()),
+            name: "Bash".into(),
+            arguments: serde_json::json!({"cmd": "ls"}),
+        });
+        let mut tool = bmsg(MessageRole::Tool, "");
+        tool.tool_results.push(ToolResult {
+            call_id: Some("c1".into()),
+            content: "y".repeat(50_000),
+            is_error: false,
+        });
+        let mut s = bsession(vec![bmsg(MessageRole::User, "task"), call, tool, reasoning]);
+
+        let warns = apply_context_budget(&mut s, 0, 4000, false);
+
+        assert!(!s.messages.iter().any(|m| m.author.as_deref() == Some("reasoning")));
+        let tr = &s
+            .messages
+            .iter()
+            .find(|m| !m.tool_results.is_empty())
+            .expect("tool result kept")
+            .tool_results[0];
+        assert!(tr.content.chars().count() < 5000, "tool output truncated");
+        assert!(warns.iter().any(|w| w.contains("reasoning")));
+        assert!(warns.iter().any(|w| w.contains("Truncated")));
+    }
+
+    #[test]
+    fn budget_token_cap_drops_oldest_keeps_task_and_recent() {
+        let mut msgs = vec![bmsg(MessageRole::User, "the original task")];
+        for i in 0..50 {
+            let role = if i % 2 == 0 {
+                MessageRole::Assistant
+            } else {
+                MessageRole::User
+            };
+            msgs.push(bmsg(role, &"word ".repeat(500)));
+        }
+        msgs.push(bmsg(MessageRole::Assistant, "FINAL RECENT MESSAGE"));
+        let mut s = bsession(msgs);
+        let before = s.messages.len();
+
+        let warns = apply_context_budget(&mut s, 2000, 0, true);
+
+        assert!(s.messages.len() < before, "older turns dropped");
+        assert_eq!(s.messages.first().unwrap().content, "the original task");
+        assert_eq!(s.messages.last().unwrap().content, "FINAL RECENT MESSAGE");
+        assert!(warns.iter().any(|w| w.contains("Context budget")));
+    }
+
+    #[test]
+    fn budget_repairs_orphan_tool_use() {
+        let mut call = bmsg(MessageRole::Assistant, "");
+        call.tool_calls.push(ToolCall {
+            id: Some("orphan".into()),
+            name: "X".into(),
+            arguments: serde_json::Value::Null,
+        });
+        let mut s = bsession(vec![bmsg(MessageRole::User, "hi"), call]);
+
+        apply_context_budget(&mut s, 0, 0, true);
+
+        // Orphan tool_use removed and the now-empty assistant turn dropped.
+        assert!(s.messages.iter().all(|m| m.tool_calls.is_empty()));
+        assert_eq!(s.messages.len(), 1);
     }
 }

--- a/src/providers/claude_code.rs
+++ b/src/providers/claude_code.rs
@@ -394,7 +394,10 @@ impl Provider for ClaudeCode {
             "writing Claude Code session"
         );
 
-        // Build JSONL content: one line per message.
+        // Build JSONL content: one line per message. Entry role follows the
+        // canonical role: tool output is classified as `Tool` upstream (in the
+        // Codex reader), which maps to a user entry here, so `tool_result`
+        // blocks land in user messages as Anthropic's API requires.
         let mut lines: Vec<String> = Vec::with_capacity(session.messages.len());
         let mut prev_uuid: Option<String> = None;
 
@@ -412,7 +415,6 @@ impl Provider for ClaudeCode {
             let entry_type = claude_entry_type(&msg.role);
             let inner_msg = build_inner_message(msg, session.model_name.as_deref(), entry_type);
 
-            // Build the full JSONL entry.
             let parent_uuid_val = match &prev_uuid {
                 Some(u) => serde_json::Value::String(u.clone()),
                 None => serde_json::Value::Null,
@@ -435,7 +437,14 @@ impl Provider for ClaudeCode {
             prev_uuid = Some(entry_uuid);
         }
 
-        let content_bytes = lines.join("\n").into_bytes();
+        // Terminate the final line with a newline. Claude Code appends new
+        // turns to this file on resume; without a trailing newline its first
+        // appended record is concatenated onto casr's last line, corrupting it.
+        let mut content = lines.join("\n");
+        if !content.is_empty() {
+            content.push('\n');
+        }
+        let content_bytes = content.into_bytes();
 
         // Use atomic write.
         let outcome =
@@ -531,24 +540,48 @@ fn claude_entry_type(role: &MessageRole) -> &'static str {
     }
 }
 
+/// Claude's API requires `tool_use.input` to be a JSON object. Source agents
+/// (notably Codex) store tool arguments as a JSON-encoded string, and some
+/// tools (e.g. apply_patch) pass a raw non-JSON string. Coerce to an object so
+/// the resumed conversation history is accepted by the API; these historical
+/// tool calls are never re-executed, only replayed as context.
+fn coerce_tool_input(arguments: &serde_json::Value) -> serde_json::Value {
+    match arguments {
+        serde_json::Value::Object(_) => arguments.clone(),
+        serde_json::Value::String(s) => match serde_json::from_str::<serde_json::Value>(s) {
+            Ok(v @ serde_json::Value::Object(_)) => v,
+            _ => serde_json::json!({ "value": s }),
+        },
+        serde_json::Value::Null => serde_json::json!({}),
+        other => serde_json::json!({ "value": other }),
+    }
+}
+
+/// Build the Anthropic `message.content` value for one entry. Assistant entries
+/// serialize text + `tool_use` blocks; non-assistant entries serialize
+/// `tool_result` blocks (when present) or a plain string. `tool_use.input` is
+/// coerced to a JSON object as the API requires.
 fn build_message_content(msg: &CanonicalMessage) -> serde_json::Value {
     match msg.role {
         MessageRole::Assistant => {
             let mut blocks: Vec<serde_json::Value> = Vec::new();
             if !msg.content.is_empty() {
-                blocks.push(serde_json::json!({
-                    "type": "text",
-                    "text": msg.content,
-                }));
+                blocks.push(serde_json::json!({ "type": "text", "text": msg.content }));
             }
             for tc in &msg.tool_calls {
                 blocks.push(serde_json::json!({
                     "type": "tool_use",
                     "id": tc.id.as_deref().unwrap_or(""),
                     "name": tc.name,
-                    "input": tc.arguments,
+                    "input": coerce_tool_input(&tc.arguments),
                 }));
             }
+            // Some source agents (e.g. Gemini) attach tool results directly to
+            // the assistant message. Preserve them so multi-hop conversions stay
+            // lossless. (Codex tool output is reclassified as Tool role upstream,
+            // so codex→claude assistant messages never reach this branch with
+            // results — keeping tool_result blocks out of assistant turns for the
+            // common resume path.)
             for tr in &msg.tool_results {
                 blocks.push(serde_json::json!({
                     "type": "tool_result",
@@ -589,10 +622,31 @@ fn build_inner_message(
     });
     if let Some(ref author) = msg.author {
         inner_msg["model"] = serde_json::Value::String(author.clone());
-    } else if msg.role == MessageRole::Assistant
+    } else if entry_type == "assistant"
         && let Some(model) = session_model_name
     {
         inner_msg["model"] = serde_json::Value::String(model.to_string());
+    }
+    // Claude Code's resume loader expects assistant messages to carry the full
+    // Anthropic message envelope (id / type / model / stop_reason / usage), the
+    // same shape its own API responses are persisted in. When these fields are
+    // missing, `claude --resume` hangs on load and ultimately reports
+    // "Failed to resume session". The source agent does not provide real values,
+    // so synthesize benign defaults; provenance (source model) is preserved in
+    // the `model` field set above when available.
+    if entry_type == "assistant" {
+        inner_msg["id"] =
+            serde_json::Value::String(format!("msg_casr_{}", uuid::Uuid::new_v4().simple()));
+        inner_msg["type"] = serde_json::Value::String("message".to_string());
+        if inner_msg.get("model").is_none() {
+            inner_msg["model"] = serde_json::Value::String("unknown".to_string());
+        }
+        inner_msg["stop_reason"] = serde_json::Value::String("end_turn".to_string());
+        inner_msg["stop_sequence"] = serde_json::Value::Null;
+        inner_msg["usage"] = serde_json::json!({
+            "input_tokens": 0,
+            "output_tokens": 0,
+        });
     }
     inner_msg
 }
@@ -698,43 +752,54 @@ mod tests {
         });
 
         let content = build_message_content(&msg);
-        let blocks = content
-            .as_array()
-            .expect("assistant content should be serialized as blocks");
+        let blocks = content.as_array().expect("assistant content is blocks");
         assert_eq!(blocks.len(), 2);
         assert_eq!(blocks[0]["type"], "text");
-        assert_eq!(blocks[0]["text"], "Plan generated.");
         assert_eq!(blocks[1]["type"], "tool_use");
         assert_eq!(blocks[1]["id"], "tool-1");
-        assert_eq!(blocks[1]["name"], "Read");
+        assert_eq!(blocks[1]["input"]["file_path"], "src/main.rs");
     }
 
     #[test]
-    fn writer_non_assistant_tool_results_serialize_as_blocks() {
+    fn writer_coerces_string_tool_input_to_object() {
+        let mut msg = sample_message(MessageRole::Assistant, "");
+        msg.tool_calls.push(ToolCall {
+            id: Some("c1".to_string()),
+            name: "shell".to_string(),
+            arguments: serde_json::Value::String("{\"cmd\":\"ls\"}".to_string()),
+        });
+        let content = build_message_content(&msg);
+        let blocks = content.as_array().unwrap();
+        assert!(blocks[0]["input"].is_object());
+        assert_eq!(blocks[0]["input"]["cmd"], "ls");
+    }
+
+    #[test]
+    fn writer_tool_results_serialize_as_user_blocks() {
         let mut msg = sample_message(MessageRole::Tool, "");
         msg.tool_results.push(ToolResult {
             call_id: Some("call-42".to_string()),
             content: "Done".to_string(),
             is_error: false,
         });
-
         let content = build_message_content(&msg);
-        let blocks = content
-            .as_array()
-            .expect("tool result content should be serialized as blocks");
+        let blocks = content.as_array().expect("tool result content is blocks");
         assert_eq!(blocks.len(), 1);
         assert_eq!(blocks[0]["type"], "tool_result");
         assert_eq!(blocks[0]["tool_use_id"], "call-42");
         assert_eq!(blocks[0]["content"], "Done");
-        assert_eq!(blocks[0]["is_error"], false);
     }
 
     #[test]
-    fn writer_inner_message_uses_fallback_model_for_assistant() {
+    fn writer_assistant_envelope_fields_present() {
         let msg = sample_message(MessageRole::Assistant, "hi");
         let inner = build_inner_message(&msg, Some("claude-3-7-sonnet"), "assistant");
         assert_eq!(inner["role"], "assistant");
         assert_eq!(inner["model"], "claude-3-7-sonnet");
+        assert_eq!(inner["type"], "message");
+        assert!(inner["id"].as_str().unwrap().starts_with("msg_casr_"));
+        assert_eq!(inner["stop_reason"], "end_turn");
+        assert!(inner["usage"].is_object());
     }
 
     #[test]

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -567,11 +567,24 @@ impl Codex {
                 }
                 "response_item" => {
                     if let Some(p) = payload {
-                        let role_str = p
-                            .get("role")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("assistant");
-                        let role = normalize_role(role_str);
+                        let payload_type =
+                            p.get("type").and_then(|v| v.as_str()).unwrap_or_default();
+                        // Tool output events (`function_call_output`) carry no
+                        // `role` and would otherwise default to "assistant",
+                        // placing their results in an assistant turn. Anthropic
+                        // (and Claude Code resume) require tool results in a user
+                        // turn, so classify them as Tool — which target writers
+                        // map to the user/tool side.
+                        let role = if matches!(
+                            payload_type,
+                            "function_call_output" | "custom_tool_call_output"
+                        ) {
+                            MessageRole::Tool
+                        } else {
+                            let role_str =
+                                p.get("role").and_then(|v| v.as_str()).unwrap_or("assistant");
+                            normalize_role(role_str)
+                        };
 
                         let content_val = p.get("content");
                         let text = codex_extract_text_content(content_val);

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -696,6 +696,82 @@ impl Codex {
                         }
                     }
                 }
+                "compacted" => {
+                    // A compaction replaces all prior history with a condensed
+                    // snapshot the source agent chose to keep in context. Reset
+                    // the accumulated messages to that `replacement_history` so
+                    // the converted session mirrors the source's *live* context
+                    // instead of replaying the full on-disk archive (a long
+                    // session can compact dozens of times; only the last
+                    // snapshot plus the events after it are actually in context).
+                    if let Some(p) = payload {
+                        let mut replacement: Vec<CanonicalMessage> = Vec::new();
+                        if let Some(items) =
+                            p.get("replacement_history").and_then(|v| v.as_array())
+                        {
+                            for item in items {
+                                let payload_type =
+                                    item.get("type").and_then(|v| v.as_str()).unwrap_or_default();
+                                let role = if matches!(
+                                    payload_type,
+                                    "function_call_output" | "custom_tool_call_output"
+                                ) {
+                                    MessageRole::Tool
+                                } else {
+                                    let role_str = item
+                                        .get("role")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("assistant");
+                                    normalize_role(role_str)
+                                };
+                                let content_val = item.get("content");
+                                let text = codex_extract_text_content(content_val);
+                                let mut tool_calls = codex_extract_tool_calls(content_val);
+                                tool_calls.extend(codex_extract_payload_tool_calls(item));
+                                let mut tool_results = codex_extract_tool_results(content_val);
+                                tool_results.extend(codex_extract_payload_tool_results(item));
+                                if text.trim().is_empty()
+                                    && tool_calls.is_empty()
+                                    && tool_results.is_empty()
+                                {
+                                    continue;
+                                }
+                                replacement.push(CanonicalMessage {
+                                    idx: 0,
+                                    role,
+                                    content: text,
+                                    timestamp: ts,
+                                    author: None,
+                                    tool_calls,
+                                    tool_results,
+                                    extra: serde_json::Value::Null,
+                                });
+                            }
+                        }
+                        // An optional free-text summary accompanying the compaction.
+                        if let Some(summary) = p.get("message").and_then(|v| v.as_str())
+                            && !summary.trim().is_empty()
+                        {
+                            replacement.push(CanonicalMessage {
+                                idx: 0,
+                                role: MessageRole::Assistant,
+                                content: summary.to_string(),
+                                timestamp: ts,
+                                author: Some("summary".to_string()),
+                                tool_calls: vec![],
+                                tool_results: vec![],
+                                extra: serde_json::Value::Null,
+                            });
+                        }
+                        debug!(
+                            line = line_num,
+                            replaced = messages.len(),
+                            kept = replacement.len(),
+                            "codex compaction: resetting history to replacement_history"
+                        );
+                        messages = replacement;
+                    }
+                }
                 _ => {
                     trace!(line = line_num, event_type, "skipping unknown event type");
                 }
@@ -1512,5 +1588,36 @@ not json
             "Assistant without usage should produce one response_item"
         );
         assert_eq!(events[0]["type"], "response_item");
+    }
+
+    #[test]
+    fn reader_jsonl_compaction_resets_to_replacement_history() {
+        // A `compacted` event replaces all prior history with its
+        // replacement_history; only that snapshot plus post-compaction events
+        // should survive (the source agent's live context).
+        let content = concat!(
+            r#"{"type":"session_meta","payload":{"id":"sx","cwd":"/tmp/p"}}"#,
+            "\n",
+            r#"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"PRE-COMPACTION ORIGINAL"}]}}"#,
+            "\n",
+            r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"pre answer"}]}}"#,
+            "\n",
+            r#"{"type":"compacted","payload":{"replacement_history":[{"type":"message","role":"user","content":[{"type":"input_text","text":"KEPT SUMMARY TASK"}]}]}}"#,
+            "\n",
+            r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"POST answer"}]}}"#,
+        );
+        let session = read_codex_jsonl(content);
+        let joined = session
+            .messages
+            .iter()
+            .map(|m| m.content.clone())
+            .collect::<Vec<_>>()
+            .join("|");
+        assert!(
+            !joined.contains("PRE-COMPACTION"),
+            "pre-compaction history must be dropped, got: {joined}"
+        );
+        assert!(joined.contains("KEPT SUMMARY TASK"), "got: {joined}");
+        assert!(joined.contains("POST answer"), "got: {joined}");
     }
 }

--- a/tests/pipeline_test.rs
+++ b/tests/pipeline_test.rs
@@ -267,6 +267,7 @@ fn options(dry_run: bool, source_hint: Option<String>) -> ConvertOptions {
         verbose: false,
         enrich: false,
         source_hint,
+        ..Default::default()
     }
 }
 
@@ -928,6 +929,7 @@ fn pipeline_real_cc_to_codex_happy_path() {
                 verbose: false,
                 enrich: false,
                 source_hint: None,
+                ..Default::default()
             },
         )
         .expect("real CC→Codex pipeline should succeed");
@@ -967,6 +969,7 @@ fn pipeline_real_cc_to_gemini_happy_path() {
                 verbose: false,
                 enrich: false,
                 source_hint: None,
+                ..Default::default()
             },
         )
         .expect("real CC→Gemini pipeline should succeed");
@@ -1000,6 +1003,7 @@ fn pipeline_real_dry_run_skips_write() {
                 verbose: false,
                 enrich: false,
                 source_hint: None,
+                ..Default::default()
             },
         )
         .expect("real dry-run should succeed");
@@ -1035,6 +1039,7 @@ fn pipeline_real_same_provider_short_circuit() {
                 verbose: false,
                 enrich: false,
                 source_hint: None,
+                ..Default::default()
             },
         )
         .expect("real same-provider should short-circuit");
@@ -1079,6 +1084,7 @@ fn pipeline_real_source_hint_narrows_resolution() {
                 verbose: false,
                 enrich: false,
                 source_hint: Some("cc".to_string()),
+                ..Default::default()
             },
         )
         .expect("source hint 'cc' should resolve to ClaudeCode");
@@ -1110,6 +1116,7 @@ fn pipeline_real_session_not_found() {
                 verbose: false,
                 enrich: false,
                 source_hint: None,
+                ..Default::default()
             },
         )
         .expect_err("real not-found should error");
@@ -1136,6 +1143,7 @@ fn pipeline_real_unknown_target_alias() {
                 verbose: false,
                 enrich: false,
                 source_hint: None,
+                ..Default::default()
             },
         )
         .expect_err("unknown alias should error");
@@ -1242,6 +1250,7 @@ fn pipeline_emits_trace_events_for_detection_read_write_verify() {
                 verbose: false,
                 enrich: false,
                 source_hint: None,
+                ..Default::default()
             },
         )
         .expect("conversion should succeed");


### PR DESCRIPTION
## Summary

Makes resuming a Codex session as a Claude Code session actually work on latest versions, and lets it handle very large sessions. Two commits:

1. Fix the Codex → Claude Code resume conversion.
2. Honor source compaction + add a context budget so huge sessions convert cleanly.

## Why

### Conversion produced unusable sessions
Converting a Codex session with `resume cc` wrote a `.jsonl` that `claude --resume` couldn't load (it hung, then reported "Failed to resume session"), and once past that, the API rejected the replayed history. Root causes, in the Claude Code writer / Codex reader:

- Assistant entries were missing the message envelope the resume loader expects (`id` / `type` / `model` / `stop_reason` / `usage`). Added it.
- `tool_use.input` was written as a JSON-encoded string; the API requires an object. Now coerced.
- Tool output (`function_call_output`) defaulted to the assistant role, so `tool_result` blocks landed in assistant turns — the API requires them in user turns. The Codex reader now classifies tool output as `Tool` role (mapping to a user turn), keeping `tool_use`/`tool_result` paired.
- The file had no trailing newline, so the first turn the client appended on resume corrupted the last line. Fixed.
- The pipeline's tool-text content synthesis (step 7b) is now skipped for the structured-tool Claude Code target, where it duplicated tool output into a text block the API rejects alongside the matching `tool_result`.

### Large sessions couldn't be converted at all
A long Codex session is an *archive*: it can be hundreds of MB on disk while the agent's *live* context is only a few MB, because Codex compacts repeatedly (one real session here compacted 108 times — 147 MB on disk, ~2 MB live). Replaying the whole archive blew the target's resume size limit / context window.

- The Codex reader now honors `compacted` events: each resets the accumulated history to that compaction's `replacement_history`, so a conversion reflects the source's live context, not its full log. (That 147 MB / 108-compaction session now produces a ~1 MB Claude Code session.)
- Added a cross-provider context budget: drop the source agent's hidden reasoning (unusable by a different agent), truncate oversized tool observations, then drop the oldest turns past a token cap — always pinning the original task message and recent history, and repairing tool_use/tool_result pairing so nothing is left unmatched. Every elision is surfaced as a warning, never silent.
- New flags (defaults make handoffs work out of the box): `--max-context-tokens` (default 200000), `--max-tool-output` (default 4000), `--keep-reasoning`.

## Testing locally
```
cargo build --release
cargo test --release        # codex / claude_code / pipeline / golden / roundtrip
```
End-to-end with a real Codex session:
```
casr resume cc <codex-session-id> --source <path-to-rollout.jsonl> --json
# -> writes the target session and prints a resume_command
cd <the session's workspace>
claude --dangerously-skip-permissions --resume <new-id> -p "summarize the prior session"
```
- Small sessions convert losslessly (no budgeting kicks in).
- A multi-hundred-MB Codex session now converts in well under a second to a ~1 MB session and resumes; the agent summarizes the source's most recent working state accurately.
- Tune with `--max-context-tokens` / `--max-tool-output`, or pass `--keep-reasoning` to keep reasoning traces.

New unit tests cover the Codex compaction reset and the budget transform (truncation / reasoning-drop / windowing / pairing-repair).

## Notes
Other providers are unaffected: the budget only runs cross-provider, and same-provider resume short-circuits as before. Existing golden/roundtrip suites pass; the only failing tests on this branch are the pre-existing `opencode` env-mutex flakes that also fail on `main`.
