### PR TITLE
cli: correct documented resume argument order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ We only use **Cargo** in this project, NEVER any other package manager.
 
 | Crate | Purpose |
 |-------|---------|
-| `clap` + `clap_complete` | CLI argument parsing and shell completions (`casr <target> resume <session-id>`) |
+| `clap` + `clap_complete` | CLI argument parsing and shell completions (`casr resume <target> <session-id>`) |
 | `serde` + `serde_json` | Canonical session model + provider format parsing/writing |
 | `anyhow` + `thiserror` | Internal propagation + actionable user-facing errors |
 | `chrono` | Timestamp normalization (ISO-8601, epoch seconds/millis) |
@@ -559,7 +559,7 @@ casr runs in interactive CLI loops, so latency matters:
 casr is a command-line tool (not a hook protocol). Primary command shape:
 
 ```bash
-casr <target> resume <session-id> [--source <alias_or_path>] [--dry-run] [--force] [--json] [--verbose|--trace] [--enrich]
+casr resume <target> <session-id> [--source <alias_or_path>] [--dry-run] [--force] [--json] [--verbose|--trace] [--enrich]
 ```
 
 Additional command shapes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,7 @@ All 14 providers were implemented via a pluggable `Provider` trait with `detect`
 
 ### CLI and UX
 
-- **Subcommand and shorthand resume**: both `casr <target> resume <id>` and `casr -cc <id>` / `casr -cod <id>` / `casr -gmi <id>` forms supported; shorthand flags rewritten internally before clap parsing ([`ebc7204`](https://github.com/Dicklesworthstone/cross_agent_session_resumer/commit/ebc72044a618ff72a41c11442c27067e9f2c3d8c)).
+- **Subcommand and shorthand resume**: both `casr resume <target> <id>` and `casr -cc <id>` / `casr -cod <id>` / `casr -gmi <id>` forms supported; shorthand flags rewritten internally before clap parsing ([`ebc7204`](https://github.com/Dicklesworthstone/cross_agent_session_resumer/commit/ebc72044a618ff72a41c11442c27067e9f2c3d8c)).
 - **Rich terminal table for `casr list`**: styled columns for provider, session ID, workspace, message count, tool-use count, and relative last-active age ([`ebc7204`](https://github.com/Dicklesworthstone/cross_agent_session_resumer/commit/ebc72044a618ff72a41c11442c27067e9f2c3d8c), [`dc16517`](https://github.com/Dicklesworthstone/cross_agent_session_resumer/commit/dc16517ae34d9877f6c2bfb44a81b58bf59ff0d9)).
 - **Workspace-scoped list**: `casr list` defaults to sessions from the current working directory; `--workspace` overrides explicitly ([`474e765`](https://github.com/Dicklesworthstone/cross_agent_session_resumer/commit/474e765f6cb2d7907e83c9aab631211930ed9442)).
 - **Standard provider name aliases**: `claude` -> `claude-code`, `codex-cli` -> `codex`, `gemini-cli` -> `gemini` for natural command invocation ([`80c5789`](https://github.com/Dicklesworthstone/cross_agent_session_resumer/commit/80c5789d06770aca4d571ffe3e1cc070b58d7440)).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ That installer is the primary distribution path. It handles platform detection, 
 
 | Feature | What It Does |
 |---|---|
-| Cross-provider resume | `casr cc resume <codex-session-id>` and similar conversions in one command |
+| Cross-provider resume | `casr resume cc <codex-session-id>` and similar conversions in one command |
 | Canonical IR | Normalizes provider formats into a common model, then exports back to native format |
 | Native-format writers | Produces plausible provider-native session files, not intermediate-only exports |
 | Safety-first writes | Atomic temp-then-rename writes, conflict detection, optional `.bak` backup with `--force` |
@@ -50,7 +50,7 @@ casr list --limit 20 --sort date
 casr info 019c3eae-94c3-7d73-9b2a-9edb18f1563b
 
 # 4) Convert that session to Claude Code format
-casr cc resume 019c3eae-94c3-7d73-9b2a-9edb18f1563b
+casr resume cc 019c3eae-94c3-7d73-9b2a-9edb18f1563b
 
 # ergonomic shorthand (auto-detects source provider from the session ID)
 casr -cc 019c3eae-94c3-7d73-9b2a-9edb18f1563b   # open in Claude Code
@@ -216,19 +216,19 @@ Global flags:
 --enrich                  # Add optional synthetic context/orientation messages
 ```
 
-### `casr <target> resume <session-id>`
+### `casr resume <target> <session-id>`
 
 Convert a source session into target provider format and print the target resume command.
 
 ```bash
-casr cc resume 019c3eae-94c3-7d73-9b2a-9edb18f1563b
-casr claude resume 019c3eae-94c3-7d73-9b2a-9edb18f1563b   # standard name fallback
-casr cod resume 40f2cb68-fed7-4cee-83de-2b63ba9b7813 --dry-run
-casr codex resume 40f2cb68-fed7-4cee-83de-2b63ba9b7813 --dry-run
-casr gmi resume 40f2cb68-fed7-4cee-83de-2b63ba9b7813 --source cc
-casr gemini resume 40f2cb68-fed7-4cee-83de-2b63ba9b7813 --source claude
-casr cc resume <session-id> --force
-casr cc resume <session-id> --json
+casr resume cc 019c3eae-94c3-7d73-9b2a-9edb18f1563b
+casr resume claude 019c3eae-94c3-7d73-9b2a-9edb18f1563b   # standard name fallback
+casr resume cod 40f2cb68-fed7-4cee-83de-2b63ba9b7813 --dry-run
+casr resume codex 40f2cb68-fed7-4cee-83de-2b63ba9b7813 --dry-run
+casr resume gmi 40f2cb68-fed7-4cee-83de-2b63ba9b7813 --source cc
+casr resume gemini 40f2cb68-fed7-4cee-83de-2b63ba9b7813 --source claude
+casr resume cc <session-id> --force
+casr resume cc <session-id> --json
 ```
 
 ### `casr list`
@@ -331,7 +331,7 @@ Important helpers:
 
 ```text
 Input CLI
-  casr <target> resume <session-id>
+  casr resume <target> <session-id>
           |
           v
 Provider Registry + Detection
@@ -390,7 +390,7 @@ Common examples:
 
 `casr` supports two equivalent resume styles:
 
-- Canonical subcommand form: `casr <target> resume <session-id>`
+- Canonical subcommand form: `casr resume <target> <session-id>`
 - Shorthand form: `casr -cc <session-id>`, `casr -cod <session-id>`, `casr -agy <session-id>`, `casr -gmi <session-id>`
 
 Shorthand flags are rewritten internally before clap parsing, so logging, JSON output, and error handling stay identical across both forms.
@@ -530,7 +530,7 @@ Recommended test set for new providers:
 
 - Reader and writer unit tests for native fixtures.
 - Round-trip tests (`read(write(read(...)))`).
-- CLI integration test path through `casr list`, `casr info`, and `casr <target> resume`.
+- CLI integration test path through `casr list`, `casr info`, and `casr resume <target>`.
 - Error-path tests for malformed input and file I/O failures.
 
 ## Provider Format Notes
@@ -637,7 +637,7 @@ Test suite coverage includes:
 ```bash
 casr list
 casr info <session-id>
-casr cc resume <session-id> --source cod
+casr resume cc <session-id> --source cod
 ```
 
 ### "Target provider not installed"
@@ -655,7 +655,7 @@ Install the missing provider, then retry.
 Use force mode to back up and overwrite:
 
 ```bash
-casr cc resume <session-id> --force
+casr resume cc <session-id> --force
 ```
 
 ### "Write verification failed"
@@ -663,7 +663,7 @@ casr cc resume <session-id> --force
 Run in trace mode and inspect JSON diagnostics:
 
 ```bash
-casr cc resume <session-id> --trace --json
+casr resume cc <session-id> --trace --json
 ```
 
 ### "Wrong source provider was detected"
@@ -671,8 +671,8 @@ casr cc resume <session-id> --trace --json
 Pin source provider or session path explicitly:
 
 ```bash
-casr cc resume <session-id> --source cod
-casr cc resume <session-id> --source ~/.codex/sessions/2026/02/06/rollout-1.jsonl
+casr resume cc <session-id> --source cod
+casr resume cc <session-id> --source ~/.codex/sessions/2026/02/06/rollout-1.jsonl
 ```
 
 ## Limitations

--- a/install.sh
+++ b/install.sh
@@ -435,7 +435,7 @@ casr -gmi <session-id>  # open in Gemini
 ```bash
 casr providers
 casr list --workspace "$(pwd)" --sort date --limit 20
-casr cod resume <session-id> --source cc
+casr resume cod <session-id> --source cc
 casr info <session-id> --json
 ```
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -180,7 +180,7 @@ impl ProviderRegistry {
 
     /// Resolve a session ID to its source provider and file path.
     ///
-    /// This is the main entry point for the `casr <target> resume <session-id>`
+    /// This is the main entry point for the `casr resume <target> <session-id>`
     /// flow. It implements a deterministic multi-step algorithm:
     ///
     /// 1. If `source_hint` is a [`SourceHint::Path`], bypass discovery entirely.

--- a/src/providers/antigravity.rs
+++ b/src/providers/antigravity.rs
@@ -334,7 +334,7 @@ impl Provider for Antigravity {
         Err(anyhow::anyhow!(
             "Antigravity (agy) is read/resume-only: casr cannot create a resumable \
              agy conversation from another provider's history. Use agy as a conversion \
-             SOURCE (e.g. `casr cc resume <agy-uuid> --source agy`), not a target."
+             SOURCE (e.g. `casr resume cc <agy-uuid> --source agy`), not a target."
         ))
     }
 


### PR DESCRIPTION
Every documented `casr <target> resume <id>` form is rejected by clap; the accepted order has been `casr resume <target> <id>` since v0.1.0.

Verify: `casr cc resume <any-id>` gives "error: unrecognized subcommand 'cc'", `casr resume cc <any-id> --dry-run` works.

LLM assistance was used to find every occurrence of the stale form and to write this patch.