### PR TITLE
feat(list): add --all and --limit 0, and match workspaces across path spellings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1070,8 +1070,8 @@ fn cmd_list(
 
                 let mut sessions: Vec<(String, PathBuf)> = Vec::new();
                 for candidate in &candidates {
-                    let expected_dir = projects_dir
-                        .join(casr::providers::claude_code::project_dir_key(candidate));
+                    let expected_dir =
+                        projects_dir.join(casr::providers::claude_code::project_dir_key(candidate));
                     let Ok(entries) = std::fs::read_dir(&expected_dir) else {
                         continue;
                     };
@@ -1437,8 +1437,11 @@ fn cmd_list(
             // Without the workspace, rows from different repos are
             // indistinguishable in an unscoped listing.
             if all_workspaces {
-                table = table
-                    .with_column(Column::new("Workspace").justify(JustifyMethod::Left).width(20));
+                table = table.with_column(
+                    Column::new("Workspace")
+                        .justify(JustifyMethod::Left)
+                        .width(20),
+                );
             }
             table = table
                 .with_column(Column::new("Msgs").justify(JustifyMethod::Right).width(6))

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,13 @@ enum Command {
         #[arg(long)]
         workspace: Option<String>,
 
-        /// Maximum sessions to show per provider.
+        /// List sessions from every workspace instead of only the current
+        /// project. Without this, `list` scopes to the working directory, which
+        /// hides sessions recorded in other repos.
+        #[arg(long, conflicts_with = "workspace")]
+        all: bool,
+
+        /// Maximum sessions to show per provider. Use 0 for no limit.
         #[arg(long, default_value = "10")]
         limit: usize,
 
@@ -294,12 +300,14 @@ fn main() -> ExitCode {
         Command::List {
             provider,
             workspace,
+            all,
             limit,
             sort,
             enrich_fs,
         } => cmd_list(
             provider.as_deref(),
             workspace.as_deref(),
+            all,
             limit,
             &sort,
             cli.json,
@@ -454,9 +462,34 @@ fn cmd_resume(
     Ok(())
 }
 
+/// Every path spelling a workspace can legitimately take.
+///
+/// macOS resolves `/var`, `/tmp`, and `/etc` through symlinks into `/private`,
+/// so `std::env::current_dir()` reports `/private/var/...` while providers
+/// record whichever spelling the shell used (`/var/...`). Comparing a single
+/// spelling makes sessions under those directories invisible to `list`.
+fn workspace_match_candidates(ws: &Path) -> Vec<PathBuf> {
+    let mut candidates = vec![ws.to_path_buf()];
+    if let Ok(canonical) = ws.canonicalize()
+        && !candidates.contains(&canonical)
+    {
+        candidates.push(canonical);
+    }
+    // The reverse direction: canonicalization only ever *adds* the `/private`
+    // prefix, so strip it to recover the spelling a provider likely recorded.
+    if let Ok(stripped) = ws.strip_prefix("/private") {
+        let rooted = Path::new("/").join(stripped);
+        if !candidates.contains(&rooted) {
+            candidates.push(rooted);
+        }
+    }
+    candidates
+}
+
 fn cmd_list(
     provider_filter: Option<&str>,
     workspace_filter: Option<&str>,
+    all_workspaces: bool,
     limit: usize,
     sort: &str,
     json_mode: bool,
@@ -949,6 +982,10 @@ fn cmd_list(
     }
 
     fn probe_limit_for_sort(limit: usize, sort: &str, workspace_scoped: bool) -> usize {
+        // limit == 0 means "no limit", so every candidate must be scanned.
+        if limit == 0 {
+            return usize::MAX;
+        }
         if sort == "date" {
             // Cap expensive provider scans while preserving high confidence for
             // "most recent" results. Workspace-scoped lists can use a tighter cap.
@@ -968,23 +1005,36 @@ fn cmd_list(
             return true;
         };
 
+        // A workspace can be spelled more than one way (see
+        // `workspace_match_candidates`); any spelling is a legitimate match.
+        let candidates = workspace_match_candidates(ws.as_path());
+
         match provider_slug {
             "claude-code" => {
-                let expected = casr::providers::claude_code::project_dir_key(ws.as_path());
-                path.parent()
+                let observed = path
+                    .parent()
                     .and_then(|p| p.file_name())
-                    .and_then(|n| n.to_str())
-                    == Some(expected.as_str())
+                    .and_then(|n| n.to_str());
+                observed.is_some_and(|dir_name| {
+                    candidates.iter().any(|candidate| {
+                        casr::providers::claude_code::project_dir_key(candidate) == dir_name
+                    })
+                })
             }
             "gemini" => {
-                let expected_hash = casr::providers::gemini::project_hash(ws.as_path());
                 let observed_hash = path
                     .parent()
                     .and_then(|p| p.parent())
                     .and_then(|p| p.file_name())
                     .and_then(|n| n.to_str());
                 match observed_hash {
-                    Some(hash) if hash == expected_hash => true,
+                    Some(hash)
+                        if candidates.iter().any(|candidate| {
+                            casr::providers::gemini::project_hash(candidate) == hash
+                        }) =>
+                    {
+                        true
+                    }
                     Some(hash)
                         if hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()) =>
                     {
@@ -1007,34 +1057,36 @@ fn cmd_list(
         workspace_filter: Option<&PathBuf>,
     ) -> Option<Vec<(String, PathBuf)>> {
         let ws = workspace_filter?;
+        // Each spelling of the workspace maps to its own project directory, so
+        // all of them have to be collected rather than just the first.
+        let candidates = workspace_match_candidates(ws.as_path());
         match provider_slug {
             "claude-code" => {
                 let claude_home = std::env::var("CLAUDE_HOME")
                     .ok()
                     .map(PathBuf::from)
                     .or_else(|| dirs::home_dir().map(|h| h.join(".claude")))?;
-                let expected_dir = claude_home
-                    .join("projects")
-                    .join(casr::providers::claude_code::project_dir_key(ws.as_path()));
-                if !expected_dir.is_dir() {
-                    return Some(vec![]);
-                }
+                let projects_dir = claude_home.join("projects");
 
                 let mut sessions: Vec<(String, PathBuf)> = Vec::new();
-                let entries = match std::fs::read_dir(&expected_dir) {
-                    Ok(entries) => entries,
-                    Err(_) => return Some(vec![]),
-                };
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if !path.is_file() || path.extension().and_then(|e| e.to_str()) != Some("jsonl")
-                    {
-                        continue;
-                    }
-                    let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                for candidate in &candidates {
+                    let expected_dir = projects_dir
+                        .join(casr::providers::claude_code::project_dir_key(candidate));
+                    let Ok(entries) = std::fs::read_dir(&expected_dir) else {
                         continue;
                     };
-                    sessions.push((stem.to_string(), path));
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if !path.is_file()
+                            || path.extension().and_then(|e| e.to_str()) != Some("jsonl")
+                        {
+                            continue;
+                        }
+                        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                            continue;
+                        };
+                        sessions.push((stem.to_string(), path));
+                    }
                 }
                 Some(sessions)
             }
@@ -1044,9 +1096,16 @@ fn cmd_list(
                     .map(PathBuf::from)
                     .or_else(|| dirs::home_dir().map(|h| h.join(".gemini")))?;
                 let tmp_root = gemini_home.join("tmp");
-                let hash = casr::providers::gemini::project_hash(ws.as_path());
-                let chats_dir = tmp_root.join(hash).join("chats");
-                if !chats_dir.is_dir() {
+                let chats_dirs: Vec<PathBuf> = candidates
+                    .iter()
+                    .map(|candidate| {
+                        tmp_root
+                            .join(casr::providers::gemini::project_hash(candidate))
+                            .join("chats")
+                    })
+                    .filter(|dir| dir.is_dir())
+                    .collect();
+                if chats_dirs.is_empty() {
                     // Fallback to generic provider enumeration when tmp/ has
                     // legacy/non-hash chat roots (fixtures or older layouts).
                     // Otherwise, return empty early to avoid an expensive scan.
@@ -1071,27 +1130,28 @@ fn cmd_list(
                 }
 
                 let mut sessions: Vec<(String, PathBuf)> = Vec::new();
-                let entries = match std::fs::read_dir(&chats_dir) {
-                    Ok(entries) => entries,
-                    Err(_) => return Some(vec![]),
-                };
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if !path.is_file() {
-                        continue;
-                    }
-                    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                for chats_dir in &chats_dirs {
+                    let Ok(entries) = std::fs::read_dir(chats_dir) else {
                         continue;
                     };
-                    if !(name.starts_with("session-") && name.ends_with(".json")) {
-                        continue;
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if !path.is_file() {
+                            continue;
+                        }
+                        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                            continue;
+                        };
+                        if !(name.starts_with("session-") && name.ends_with(".json")) {
+                            continue;
+                        }
+                        let session_id = name
+                            .strip_prefix("session-")
+                            .and_then(|n| n.strip_suffix(".json"))
+                            .unwrap_or(name)
+                            .to_string();
+                        sessions.push((session_id, path));
                     }
-                    let session_id = name
-                        .strip_prefix("session-")
-                        .and_then(|n| n.strip_suffix(".json"))
-                        .unwrap_or(name)
-                        .to_string();
-                    sessions.push((session_id, path));
                 }
                 Some(sessions)
             }
@@ -1100,14 +1160,22 @@ fn cmd_list(
     }
 
     let workspace_filter_explicit = workspace_filter.is_some();
-    let workspace_filter = workspace_filter
-        .map(expand_tilde_path)
-        .or_else(|| std::env::current_dir().ok());
+    // `--all` is the only way to get an unscoped listing: without it the filter
+    // falls back to the cwd, so sessions recorded in other repos stay hidden.
+    let workspace_filter = if all_workspaces {
+        None
+    } else {
+        workspace_filter
+            .map(expand_tilde_path)
+            .or_else(|| std::env::current_dir().ok())
+    };
     let workspace_scope = workspace_filter
         .as_ref()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| "all workspaces".to_string());
-    let workspace_scope_label = if workspace_filter_explicit {
+    let workspace_scope_label = if all_workspaces {
+        "every workspace (--all)"
+    } else if workspace_filter_explicit {
         "workspace project (--workspace)"
     } else {
         "current working-directory project"
@@ -1238,8 +1306,14 @@ fn cmd_list(
     }
 
     if let Some(filter) = workspace_filter.as_ref() {
+        let filter_candidates = workspace_match_candidates(filter);
         sessions.retain(|s| {
-            s.workspace.as_ref().is_some_and(|w| w.starts_with(filter))
+            let workspace_matches = s.workspace.as_ref().is_some_and(|w| {
+                workspace_match_candidates(w)
+                    .iter()
+                    .any(|w| filter_candidates.iter().any(|f| w.starts_with(f)))
+            });
+            workspace_matches
                 || (provider_has_workspace_path_hint(&s.provider)
                     && workspace_hint_matches(&s.provider, &s.path, Some(filter)))
         });
@@ -1269,7 +1343,9 @@ fn cmd_list(
                 ));
             }
         }
-        provider_sessions.truncate(limit);
+        if limit > 0 {
+            provider_sessions.truncate(limit);
+        }
     }
 
     let non_empty_group_count = sessions_by_provider
@@ -1306,13 +1382,26 @@ fn cmd_list(
         }
 
         let console = Console::new();
-        console.print(&format!(
-            "[bold cyan]Project-scoped sessions[/] for [bold]{workspace_scope}[/]"
-        ));
+        if all_workspaces {
+            console.print("[bold cyan]All sessions[/] across [bold]every workspace[/]");
+        } else {
+            console.print(&format!(
+                "[bold cyan]Project-scoped sessions[/] for [bold]{workspace_scope}[/]"
+            ));
+        }
         console.print(&format!("[dim]Scope:[/] [bold]{workspace_scope_label}[/]"));
-        console.print(&format!(
-            "[dim]Showing up to[/] [bold]{limit}[/] [dim]most recent sessions per provider[/]"
-        ));
+        if limit > 0 {
+            console.print(&format!(
+                "[dim]Showing up to[/] [bold]{limit}[/] [dim]most recent sessions per provider[/]"
+            ));
+        } else {
+            console.print("[dim]Showing[/] [bold]all[/] [dim]sessions per provider[/]");
+        }
+        if !all_workspaces {
+            console.print(
+                "[dim]Tip:[/] pass [bold]--all[/] [dim]to include sessions from other workspaces[/]",
+            );
+        }
 
         let now_millis = Utc::now().timestamp_millis();
 
@@ -1328,17 +1417,30 @@ fn cmd_list(
                 provider_sessions.len()
             ));
 
+            let scope_suffix = if all_workspaces {
+                "Across All Workspaces"
+            } else {
+                "in This Project"
+            };
             let mut table = Table::new()
                 .title(format!(
-                    "Top {} Most Recently Active {} Sessions in This Project",
+                    "Top {} Most Recently Active {} Sessions {}",
                     provider_sessions.len(),
-                    provider
+                    provider,
+                    scope_suffix
                 ))
                 .header_style(Style::parse("bold black on bright_white").unwrap_or_default())
                 .border_style(Style::parse("cyan").unwrap_or_default())
                 .with_column(Column::new("#").justify(JustifyMethod::Right).width(3))
                 .with_column(Column::new("Session ID").min_width(36))
-                .with_column(Column::new("Name").justify(JustifyMethod::Left).width(24))
+                .with_column(Column::new("Name").justify(JustifyMethod::Left).width(24));
+            // Without the workspace, rows from different repos are
+            // indistinguishable in an unscoped listing.
+            if all_workspaces {
+                table = table
+                    .with_column(Column::new("Workspace").justify(JustifyMethod::Left).width(20));
+            }
+            table = table
                 .with_column(Column::new("Msgs").justify(JustifyMethod::Right).width(6))
                 .with_column(
                     Column::new("Size KB")
@@ -1388,10 +1490,22 @@ fn cmd_list(
                 let started = s.started_at_display();
                 let last_active = s.last_active_display(now_millis);
                 let last_active_cell_style = last_active_style(s.last_active_at, now_millis);
-                table.add_row(Row::new(vec![
+                let workspace_label = s
+                    .workspace
+                    .as_ref()
+                    .and_then(|w| w.file_name())
+                    .and_then(|n| n.to_str())
+                    .map(|n| truncate_display_name(n, 18))
+                    .unwrap_or_default();
+                let mut cells = vec![
                     Cell::new(rank.as_str()),
                     Cell::new(session_id),
                     Cell::new(native_name.as_str()),
+                ];
+                if all_workspaces {
+                    cells.push(Cell::new(workspace_label.as_str()));
+                }
+                cells.extend(vec![
                     Cell::new(messages.as_str()).style(messages_cell_style),
                     Cell::new(size_kb.as_str()),
                     Cell::new(unique_users.as_str()),
@@ -1399,7 +1513,8 @@ fn cmd_list(
                     Cell::new(tool_uses.as_str()),
                     Cell::new(started.as_str()),
                     Cell::new(last_active.as_str()).style(last_active_cell_style),
-                ]));
+                ]);
+                table.add_row(Row::new(cells));
             }
 
             console.print_renderable(&table);

--- a/tests/cli_e2e_test.rs
+++ b/tests/cli_e2e_test.rs
@@ -387,6 +387,118 @@ fn cli_list_limit_applies_per_provider() {
     }
 }
 
+/// Collect `session_id` values from a `list --json` invocation.
+fn list_session_ids(output: &std::process::Output) -> Vec<String> {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("list --json should emit valid JSON");
+    parsed["items"]
+        .as_array()
+        .expect("list --json items should be an array")
+        .iter()
+        .filter_map(|s| s["session_id"].as_str().map(str::to_string))
+        .collect()
+}
+
+#[test]
+fn cli_list_all_includes_sessions_from_every_workspace() {
+    let tmp = TempDir::new().unwrap();
+    let myapp_id = setup_cc_fixture(&tmp, "cc_simple"); // /data/projects/myapp
+    let webapp_id = setup_cc_fixture(&tmp, "cc_complex"); // /data/projects/webapp
+
+    // Default scope is the cwd, which matches neither fixture workspace.
+    let scoped = casr_cmd(&tmp)
+        .args(["--json", "list"])
+        .output()
+        .expect("list should run");
+    assert!(scoped.status.success());
+    let scoped_ids = list_session_ids(&scoped);
+    assert!(
+        !scoped_ids.contains(&myapp_id) && !scoped_ids.contains(&webapp_id),
+        "cwd-scoped list must not surface other workspaces, got {scoped_ids:?}"
+    );
+
+    // `--all` drops the workspace filter entirely.
+    let all = casr_cmd(&tmp)
+        .args(["--json", "list", "--all"])
+        .output()
+        .expect("list --all should run");
+    assert!(all.status.success());
+    let all_ids = list_session_ids(&all);
+    assert!(
+        all_ids.contains(&myapp_id),
+        "expected myapp session with --all, got {all_ids:?}"
+    );
+    assert!(
+        all_ids.contains(&webapp_id),
+        "expected webapp session with --all, got {all_ids:?}"
+    );
+}
+
+#[test]
+fn cli_list_all_conflicts_with_workspace() {
+    let tmp = TempDir::new().unwrap();
+    let output = casr_cmd(&tmp)
+        .args(["list", "--all", "--workspace", "/data/projects/myapp"])
+        .output()
+        .expect("list should run");
+
+    assert!(
+        !output.status.success(),
+        "--all combined with --workspace must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected a clap conflict error, got: {stderr}"
+    );
+}
+
+#[test]
+fn cli_list_limit_zero_means_unlimited() {
+    let tmp = TempDir::new().unwrap();
+    // 12 sessions in one workspace: more than the default limit of 10.
+    let mut ids = Vec::new();
+    for i in 0..12 {
+        ids.push(setup_cc_fixture_custom(
+            &tmp,
+            "cc_simple",
+            Some("/data/projects/myapp"),
+            Some(&format!("limit-zero-{i:02}")),
+        ));
+    }
+
+    let capped = casr_cmd(&tmp)
+        .args(["--json", "list", "--workspace", "/data/projects/myapp"])
+        .output()
+        .expect("list should run");
+    assert!(capped.status.success());
+    assert_eq!(
+        list_session_ids(&capped).len(),
+        10,
+        "default limit should cap at 10"
+    );
+
+    let unlimited = casr_cmd(&tmp)
+        .args([
+            "--json",
+            "list",
+            "--workspace",
+            "/data/projects/myapp",
+            "--limit",
+            "0",
+        ])
+        .output()
+        .expect("list --limit 0 should run");
+    assert!(unlimited.status.success());
+    let unlimited_ids = list_session_ids(&unlimited);
+    assert_eq!(
+        unlimited_ids.len(),
+        ids.len(),
+        "--limit 0 should return every session, got {unlimited_ids:?}"
+    );
+}
+
 #[test]
 fn cli_list_workspace_filter_filters_sessions() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
`list` scopes to the working directory with no way out, so sessions recorded in any other repo are invisible. I lost a session for weeks this way — it was in a sibling checkout, and no combination of flags would show it.

The filter falls back to `current_dir()` and can never be `None`:

```rust
let workspace_filter = workspace_filter
    .map(expand_tilde_path)
    .or_else(|| std::env::current_dir().ok());
```

So `workspace_hint_matches`' match-everything branch is unreachable and the `"all workspaces"` label is dead code. Claude Code buckets compare by exact directory key, so `--workspace /` is not an escape hatch either.

Adds:

- `--all` to drop the filter (conflicts with `--workspace`)
- `--limit 0` to lift the per-provider cap. The scan probe needs uncapping too, or it still truncates at 30 regardless
- a `Workspace` column under `--all`, since rows from different repos are otherwise indistinguishable
- a tip pointing at `--all` when the listing is scoped

For me that is 66 sessions instead of 10, in about half a second.

**Second fix, same symptom.** macOS resolves `/var`, `/tmp` and `/etc` into `/private`, so `current_dir()` reports `/private/var/...` while providers record whatever spelling the shell used. Comparing a single spelling makes those sessions unreachable even when correctly scoped. The fast path was worse: it built one expected directory and returned empty when it was missing, short-circuiting the fallback. Matching against every candidate spelling fixes both.

That was a real bug, not just a test artifact — `cli_list_shows_full_session_id_and_last_active_for_current_project_scope` fails on macOS at current `main` and passes here. Worth checking whether CI runs macOS.

Three new e2e tests cover `--all` across workspaces, the `--workspace` conflict, and `--limit 0` returning all 12 fixtures where the default caps at 10. `cli_e2e_test` is 62/62 on macOS with this branch.

Note: 9 `providers::opencode` tests still fail on macOS at `main` for a related but separate reason (writer and discovery disagree on spelling, and the first failure poisons a shared test mutex). Not touched here — happy to send that separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)